### PR TITLE
Allow setting the initializer options of 'discovery-swarm' through the DNA

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Add the following dna per every cell which needs to communicate with a single ch
   "source": "organic-plasma-channel",
   "port": Number,
   "channelName": String,
+  "swarmOpts": {},
   "emitReady": String || false,
   "log": false,
   "debug": false,
@@ -26,6 +27,7 @@ Add the following dna per every cell which needs to communicate with a single ch
 
 * `port` is *optional* but if provided should be different for different cells on single host
 * `emitReady` accepts `false` or `String` values, when String is provided it will be used to emit a chemical of that type when ready and listening for peers
+* `swarmOpts` is *optional* and if present will be passed as-is to [`discovery-swarm`'s constructor](https://github.com/mafintosh/discovery-swarm#var-sw--swarmopts)
 
 ## use
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = function (plasma, dna) {
   // decorate plasma with feedback support just in case it is not
   plasma = plasmaFeedback(plasma)
   // create discovery-swarm
-  var sw = swarm()
+  var sw = swarm(dna.swarmOpts || {})
   sw.join(dna.channelName) // can be any id/name/hash
   if (dna.port) {
     sw.listen(dna.port)


### PR DESCRIPTION
## General

This PR extends the DNA of the organelle with `swarmOpts` (*optional, object*) which if present will be passed as-is to [`discovery-swarm`'s constructor](https://github.com/mafintosh/discovery-swarm#var-sw--swarmopts). This way when initializing the organelle, one can configure various aspects of `discovery-swarm` (and its underlying  `discovery-channel`, `bittorent-dht` and `dns-discovery` dependencies). I.e:

- Setting whitelisted IPs:

```
{ 
 "source": "organic-plasma-channel",
  ...
  "swarmOpts": {
    "whitelist": ["1.2.3.4"]
  }
  ...
}
```

- Configuring various aspects of [`discovery-channel`](https://github.com/maxogden/discovery-channel#var-channel--dcopts) such as the `dht-discovery`:

```
{ 
 "source": "organic-plasma-channel",
  ...
  "swarmOpts": {
    "utp": false,
    "dht": false
  }
  ...
}
```