### PR TITLE
Add test for now resolved issue

### DIFF
--- a/test/e2e/general.test.js
+++ b/test/e2e/general.test.js
@@ -91,4 +91,26 @@ describe('e2e general', function () {
       next()
     })
   })
+
+  it('sends chemical from master to child (with feedback with error)', function (next) {
+    plasmaChild.on({
+      channel: channelName
+    }, function (c, respond) {
+      expect(c.type).to.eq('c1')
+      var err = new Error('test error')
+      err.someProp = 'someValue'
+      respond(err)
+    })
+    plasmaMaster.emit({
+      type: 'c1',
+      channel: channelName
+    }, function (err, result) {
+      expect(err).to.exist
+      expect(err).to.be.an('object')
+      expect(err.message).to.eq('test error')
+      expect(err.someProp).to.eq('someValue')
+      expect(result).to.not.exist
+      next()
+    })
+  })
 })


### PR DESCRIPTION
This PR extends the `general` e2e test for the case where an error (`Error` instance) is passed down the callback. This test would fail before the `2.0.0` version due to a now resolved issue in the way errors are serialized