### PR TITLE
Showcase response not returned error

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function replaceErrors (key, value) {
     })
     return error
   }
-  return value
+  return value || null
 }
 
 module.exports = function (plasma, dna) {

--- a/test/e2e/general.test.js
+++ b/test/e2e/general.test.js
@@ -75,6 +75,7 @@ describe('e2e general', function () {
       next()
     })
   })
+
   it('sends chemical from master to child (with feedback)', function (next) {
     plasmaChild.on({
       channel: channelName

--- a/test/e2e/general.test.js
+++ b/test/e2e/general.test.js
@@ -91,4 +91,21 @@ describe('e2e general', function () {
       next()
     })
   })
+
+  it('sends chemical from child to master (with feedback, but no data)', function (next) {
+    plasmaMaster.on({
+      channel: channelName
+    }, function (c, respond) {
+      expect(c.type).to.eq('c1')
+      respond()
+    })
+    plasmaChild.emit({
+      type: 'c1',
+      channel: channelName
+    }, function (err, result) {
+      expect(err).to.not.exist
+      expect(result).to.not.exist
+      next()
+    })
+  })
 })


### PR DESCRIPTION
# Fix `replaceErrors` method

## Problem

If the given value is `undefined` the method returns `undefined`, which causes the `JSON.parse` method to throw an error 

```
Uncaught SyntaxError: Unexpected token u in JSON at position 0
```

## Solution

If the value is `undefined` - return `null` instead of `undefined`.
:heavy_plus_sign: test is added