### PR TITLE
Parallel chemical callbacks issue

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -16,9 +16,11 @@ module.exports = function (connection, dna) {
     })
   }
   jsonConnection.onceChemical = function (pattern, callback) {
-    jsonConnection.once('message', function (c) {
+    var callbackCalled = false
+    jsonConnection.on('message', function (c) {
       if (dna.debug) console.log(dna.port, 'onceChemical', c, pattern)
-      if (plasmaUtils.deepEqual(pattern, c)) {
+      if (plasmaUtils.deepEqual(pattern, c) && !callbackCalled) {
+        callbackCalled = true
         callback(c)
       }
     })

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -17,13 +17,16 @@ module.exports = function (connection, dna) {
   }
   jsonConnection.onceChemical = function (pattern, callback) {
     var callbackCalled = false
-    jsonConnection.on('message', function (c) {
+    var handler = function (c) {
       if (dna.debug) console.log(dna.port, 'onceChemical', c, pattern)
       if (plasmaUtils.deepEqual(pattern, c) && !callbackCalled) {
         callbackCalled = true
         callback(c)
+        jsonConnection.removeListener('message', handler)
       }
-    })
+    }
+
+    jsonConnection.on('message', handler)
   }
   return jsonConnection
 }

--- a/lib/json-socket.js
+++ b/lib/json-socket.js
@@ -164,7 +164,8 @@ var delegates = [
   'once',
   'end',
   'setTimeout',
-  'setKeepAlive'
+  'setKeepAlive',
+  'removeListener'
 ]
 
 delegates.forEach(function (method) {

--- a/test/e2e/general.test.js
+++ b/test/e2e/general.test.js
@@ -131,4 +131,50 @@ describe('e2e general', function () {
       next()
     })
   })
+
+
+
+  it('sends two parallel chemical from child to master (with feedback and data)', function (next) {
+    var c1CallbackHit = false
+    var c2CallbackHit = false
+
+    plasmaMaster.on({
+      type: 'c1',
+      channel: channelName
+    }, function (c, respond) {
+      expect(c.type).to.eq('c1')
+      respond('ok c1')
+    })
+    plasmaMaster.on({
+      type: 'c2',
+      channel: channelName
+    }, function (c, respond) {
+      expect(c.type).to.eq('c2')
+      respond('ok c2')
+    })
+
+    plasmaChild.emit({
+      type: 'c1',
+      channel: channelName
+    }, function (err, result) {
+      expect(err).to.not.exist
+      expect(result).to.exist
+      c1CallbackHit = true
+    })
+
+    plasmaChild.emit({
+      type: 'c2',
+      channel: channelName
+    }, function (err, result) {
+      expect(err).to.not.exist
+      expect(result).to.exist
+      c2CallbackHit = true
+    })
+
+    setTimeout(function () {
+      expect(c1CallbackHit).to.eq(true)
+      expect(c2CallbackHit).to.eq(true)
+      next()
+    }, 1000)
+  })
 })

--- a/test/e2e/general.test.js
+++ b/test/e2e/general.test.js
@@ -132,25 +132,23 @@ describe('e2e general', function () {
     })
   })
 
-
-
-  it('sends two parallel chemical from child to master (with feedback and data)', function (next) {
-    var c1CallbackHit = false
-    var c2CallbackHit = false
+  it('sends two parallel chemicals from child to master (with feedback and data)', function (next) {
+    var c1CallbackHit = 0
+    var c2CallbackHit = 0
 
     plasmaMaster.on({
       type: 'c1',
       channel: channelName
     }, function (c, respond) {
       expect(c.type).to.eq('c1')
-      respond('ok c1')
+      respond(null, 'ok c1')
     })
     plasmaMaster.on({
       type: 'c2',
       channel: channelName
     }, function (c, respond) {
       expect(c.type).to.eq('c2')
-      respond('ok c2')
+      respond(null, 'ok c2')
     })
 
     plasmaChild.emit({
@@ -159,7 +157,7 @@ describe('e2e general', function () {
     }, function (err, result) {
       expect(err).to.not.exist
       expect(result).to.exist
-      c1CallbackHit = true
+      c1CallbackHit++
     })
 
     plasmaChild.emit({
@@ -168,12 +166,12 @@ describe('e2e general', function () {
     }, function (err, result) {
       expect(err).to.not.exist
       expect(result).to.exist
-      c2CallbackHit = true
+      c2CallbackHit++
     })
 
     setTimeout(function () {
-      expect(c1CallbackHit).to.eq(true)
-      expect(c2CallbackHit).to.eq(true)
+      expect(c1CallbackHit).to.eq(1)
+      expect(c2CallbackHit).to.eq(1)
       next()
     }, 1000)
   })


### PR DESCRIPTION
## General

This PR resolves issue #7 

## Breakdown

The problem itself lied in the `connection` helper lib's `onceChemical` method. It was written with the assumption that the `once` listener can be used on the underlying discovery swarm socket. However since the `mesage` event we are listening for is emitted practically for *every* message going through the swarm, using `once` would only give us the first event which may or may not be the one needed. Since we still match every single event against the provided pattern the `on` listener is now used along with a flag to prevent hitting the callback more than once.